### PR TITLE
Fix error with Responsive core not being included.

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,6 +30,7 @@
               "node_modules/bootstrap/dist/js/bootstrap.min.js",
               "node_modules/datatables.net/js/jquery.dataTables.js",
               "node_modules/datatables.net-bs5/js/dataTables.bootstrap5.js",
+              "node_modules/datatables.net-responsive/js/dataTables.responsive.js",
               "node_modules/datatables.net-responsive-bs5/js/responsive.bootstrap5.js"
             ]
           },


### PR DESCRIPTION
Fixes https://github.com/DataTables/Dist-DataTables-Responsive-Bootstrap5/issues/1